### PR TITLE
fix: Align KPM RAN function ID with kpimon xApp expectation

### DIFF
--- a/e2sim/e2sm_examples/kpm_e2sm/src/kpm/kpm_callbacks.cpp
+++ b/e2sim/e2sm_examples/kpm_e2sm/src/kpm/kpm_callbacks.cpp
@@ -101,7 +101,7 @@ int main(int argc, char* argv[]) {
   memcpy(ranfunc_ostr->buf,e2smbuffer,er.encoded);
 
   const char* func_id_str = std::getenv("RAN_FUNC_ID");
-  ::gFuncId = func_id_str == nullptr ? 0 : std::stoi(func_id_str);
+  ::gFuncId = func_id_str == nullptr ? 2 : std::stoi(func_id_str);
 
   e2sim.register_e2sm(gFuncId, ranfunc_ostr);
   e2sim.register_subscription_callback(gFuncId, &callback_kpm_subscription_request);


### PR DESCRIPTION
Resolution for : https://github.com/o-ran-sc/sim-e2-interface/issues/6

Problem:
The e2sim KPM example registers its KPM RAN function with ID 0, However the kpimon-go xApp expects the KPM RAN function to be registered with ID 2. This mismatch causes kpimon to fail to locate the KPM function definition during subscription setup, resulting in no E2SM-KPM subscription being established between kpimon and e2sim

Fix: 
Changed the default ranFunctionId from 0 to 2 in the KPM simulator entrypoint (kpm_callbacks.cpp ) so that the E2 setup request advertises the KPM function under ID 2, matching what kpimon queries frfom e2mgr