### PR TITLE
fix: Use MeasurementType measName instead of measID in UE indication messages

### DIFF
--- a/e2sim/e2sm_examples/kpm_e2sm/src/kpm/encode_kpm.cpp
+++ b/e2sim/e2sm_examples/kpm_e2sm/src/kpm/encode_kpm.cpp
@@ -271,7 +271,7 @@ void ue_meas_kpm_report_indication_message_initialized(
     ASN_SEQUENCE_ADD(&labelList->list, labelItem);
 
     MeasurementType_t measType;
-    measType.present = MeasurementType_PR_measID;
+    measType.present = MeasurementType_PR_measName;
     uint8_t* metrics = (uint8_t *)performance_measurements[i];
     measType.choice.measName.buf = (uint8_t*)calloc(1, strlen((char*)metrics));
     memcpy(measType.choice.measName.buf, metrics, strlen((char*)metrics));


### PR DESCRIPTION
Resolution for: https://github.com/o-ran-sc/sim-e2-interface/issues/8

Problem: 
In ue_meas_kpm_report_indication_message_initialized() inside encode_kpm.cpp the MeasurementType CHOICD was set to measurmentType_PR_measID but the code actually populated the measName union branch with string data from performance_measurments[]. This mismatch between the choice discriminator and the filled union member violates ASN.1 CHOICE semantics and causes asn_check_constraints() to fail with:
Constraint validation of indication message failed.

As a result e2sim exits immediately and never sends KPM Indication messages to the RIC.

Fix:
Changed the discriminator to match the union branch being populated
